### PR TITLE
fix reload issue on navbar

### DIFF
--- a/client/src/Components/Navbar/index.js
+++ b/client/src/Components/Navbar/index.js
@@ -48,8 +48,6 @@ function Navbar() {
       await Axios('api/v1/logout');
       setIsAuth(false);
       setLoading(false);
-      setOpen(true);
-      history.push(HOME_PAGE);
     } catch (err) {
       setError('Internal server Error');
       setLoading(false);
@@ -78,11 +76,11 @@ function Navbar() {
               <Button
                 variant="outlined"
                 color="secondary"
-                onClick=""
-                href={SIGNUP_PAGE}
+                onClick={() => history.push(SIGNUP_PAGE)}
               >
                 SignUp
               </Button>
+
               <LinkItem className={classes.linkItem} linkUrl={LOGIN_PAGE}>
                 Signin
               </LinkItem>
@@ -105,8 +103,8 @@ function Navbar() {
             </>
           )}
           <Snackbar open={open} autoHideDuration={8000} onClose={handleClose}>
-            <Alert onClose={handleClose} severity={error ? 'error' : 'success'}>
-              {error || 'LogOut Successfully!'}
+            <Alert onClose={handleClose} severity="error">
+              {error}
             </Alert>
           </Snackbar>
         </Toolbar>


### PR DESCRIPTION
* remove href on signup button and use history.push to avoid reload page 
* remove history. push to the landing page after logout because auth will redirect by default/remove success msg because doesn't appear on unmounting / any need to it